### PR TITLE
Default to host where app is served from

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "homepage": "https://github.com/juttle/juttle-viewer#readme",
   "dependencies": {
-    "dot": "^1.0.3",
-    "express": "^4.13.4"
+    "express": "^4.13.4",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "babel-core": "^6.4.5",
@@ -80,7 +80,6 @@
     "sass-loader": "^3.1.2",
     "selenium-webdriver": "^2.48.2",
     "style-loader": "^0.13.0",
-    "underscore": "^1.8.3",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.12",
     "webpack-dev-middleware": "^1.5.1",

--- a/src/apps/assets/index.html
+++ b/src/apps/assets/index.html
@@ -5,7 +5,9 @@
         <title>Jut Development</title>
         <link rel="stylesheet" type="text/css" href="/assets/main.css">
         <script type="text/javascript">
-            window.JUTTLE_SERVICE_HOST = '{{=it.JUTTLE_SERVICE_HOST}}';
+            <% if (info.JUTTLE_SERVICE_HOST) { %>
+                window.JUTTLE_SERVICE_HOST = '<%= info.JUTTLE_SERVICE_HOST %>';
+            <% } %>
         </script>
     </head>
     <body class="app-body">

--- a/src/apps/index.js
+++ b/src/apps/index.js
@@ -18,9 +18,10 @@ import 'font-awesome/css/font-awesome.css';
 import './assets/sass/main.scss';
 
 // setup redux
+let juttleServiceHost = window.JUTTLE_SERVICE_HOST || window.location.host;
 const reduxRouterMiddeware = syncHistory(browserHistory);
 const createStoreWithMiddleware = applyMiddleware(reduxRouterMiddeware)(createStore);
-const store = createStoreWithMiddleware(reducers, { juttleServiceHost: window.JUTTLE_SERVICE_HOST });
+const store = createStoreWithMiddleware(reducers, { juttleServiceHost });
 observers(store);
 
 // setup main app

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,24 +3,19 @@
 let fs = require('fs');
 let path = require('path');
 let express = require('express');
-let dot = require('dot');
+let _ = require('underscore');
 
 let DIST_DIR = path.join(__dirname, '../..', 'dist');
 let INDEX_PATH = path.join(DIST_DIR, 'index.html');
 
 module.exports = (opts) => {
-
-    if (!opts.juttleServiceHost) {
-        let error = new Error('Must provide juttleServiceHost option');
-        error.code = 'NO-JS-HOST';
-        throw error;
-    }
+    opts = opts || {};
 
     let router = express.Router();
     let indexPath = opts.indexPath || INDEX_PATH;
 
     let indexTemplate = fs.readFileSync(indexPath, 'utf8');
-    let formattedIndex = dot.template(indexTemplate)({
+    let formattedIndex = _.template(indexTemplate, { variable: 'info' })({
         JUTTLE_SERVICE_HOST: opts.juttleServiceHost
     });
 


### PR DESCRIPTION
Default to served host, if juttleServiceHost is not provided.

The doT library was not working as expected. Removed for underscore
templates instead.

connects to juttle/juttle-engine#26