### PR TITLE
Fix two styling issues with layout

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,0 +1,9 @@
+# Change Log
+This file documents all notable changes to juttle-client-library. The release numbering uses [semantic versioning](http://semver.org).
+
+## Unreleased Changes
+
+### Bug Fixes
+
+- Fix issue with cutting off charts extending beyond initial view.
+- Fix issue with main-view not extending to botton of screen, when there's not enough content.

--- a/src/apps/assets/sass/main.scss
+++ b/src/apps/assets/sass/main.scss
@@ -37,12 +37,13 @@ header {
 
 .app-main {
     width: 100%;
+    height:100%;
     @include flexbox;
 }
 
 .main-view {
     @include flex-grow(1);
-    overflow: hidden;
+    overflow-x: hidden;
     margin: 15px;
 }
 


### PR DESCRIPTION
1. The main view wasn't stretching to the bottom with no content.
2. There was a boneheaded error charts expanding beyond the initial
main-view area were getting cut off. Fixed that.

@go-oleg 