### PR TITLE
dependencies: bump juttle-client-library to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "isomorphic-fetch": "^2.2.1",
     "isparta": "^4.0.0",
     "json-loader": "^0.5.4",
-    "juttle-client-library": "0.3.0",
+    "juttle-client-library": "^0.4.0",
     "mock-socket": "^2.0.0",
     "nock": "^7.0.2",
     "node-sass": "^3.4.2",

--- a/src/apps/components/run/index.js
+++ b/src/apps/components/run/index.js
@@ -43,7 +43,10 @@ class RunApp extends React.Component {
     runView = () => {
         let { dispatch } = this.props;
 
-        this.view.run(this.props.bundle, this.inputs.getValues())
+        this.inputs.getValues()
+        .then((values) => {
+            return this.view.run(this.props.bundle, values);
+        })
         .then(jobEvents => {
             jobEvents.on('error', (err) => { dispatch(actions.newError(err)) });
             jobEvents.on('warning', (warning) => { dispatch(actions.newError(warning)) });


### PR DESCRIPTION
The API for inputs.getValues() changed to return a promise so fix code accordingly.

@mnibecker 