### PR TITLE
input area: run when enter is pressed

### DIFF
--- a/src/apps/components/run/index.js
+++ b/src/apps/components/run/index.js
@@ -7,15 +7,22 @@ import * as actions from '../../actions';
 import Juttle from 'juttle-client-library';
 import JuttleViewer from './juttle-viewer';
 
+const ENTER_KEY = 13;
 
 class RunApp extends React.Component {
     componentDidMount() {
         // construct client plus views and inputs
         let client = new Juttle(this.props.juttleServiceHost);
         this.view = new client.View(this.refs.juttleViewLayout);
-        this.inputs = new client.Input(this.refs.juttleInputGroups);
+        this.inputs = new client.Input(this.refs.juttleInputsContainer);
         this.errors = new client.Errors(this.refs.errorView);
     }
+
+    _onInputContainerKeyDown = (e) => {
+        if (e.keyCode === ENTER_KEY) {
+            this.runView();
+        }
+    };
 
     componentWillReceiveProps(nextProps) {
         let self = this;
@@ -67,7 +74,7 @@ class RunApp extends React.Component {
                     <div ref="errorView"></div>
                 </div>
                 <div className="right-rail">
-                    <div ref="juttleInputGroups"></div>
+                    <div ref="juttleInputsContainer" onKeyDown={this._onInputContainerKeyDown}></div>
                     <button
                         onClick={this.handleRunClick}
                         disabled={!this.props.bundle}


### PR DESCRIPTION
Run program when `shift+enter`, `ctrl+enter`, or `cmd+enter` is pressed.

This functionality was originally in [juttle-client-library](https://github.com/juttle/juttle-client-library), but wasn't working (see https://github.com/juttle/juttle-client-library/pull/49).

Also `s/juttleInputGroups/juttleInputsContainer/g` since that feels like a more appropriate name.

@mnibecker @rlgomes @demmer 

cc @dmehra 