### PR TITLE
Add production vs. development mode for webpack

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,6 +1,12 @@
 # Change Log
 This file documents all notable changes to juttle-client-library. The release numbering uses [semantic versioning](http://semver.org).
 
+## Unrelease Changes
+
+## Minor Changes
+
+- Uglify webpack build bundle on production builds. [#22](https://github.com/juttle/juttle-viewer/pull/22) 
+
 ## 0.1.2
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint bin src test",
     "shrinkwrap": "npm-shrinkwrap",
     "clean": "rimraf dist",
-    "build": "webpack && cp src/apps/assets/index.html dist",
+    "build": "NODE_ENV=production webpack && cp src/apps/assets/index.html dist",
     "prepublish": "npm run clean && npm run build"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ var config = {
 };
 
 if (env === 'production') {
+    config['devtool'] = 'source-map';
     config.plugins.push(
         new webpack.optimize.UglifyJsPlugin({
             compressor: {
@@ -65,8 +66,7 @@ if (env === 'production') {
             }
         })
     );
-}
-else {
+} else {
     config['devtool'] = 'cheap-module-eval-source-map';
     config.plugins.push(new webpack.NoErrorsPlugin());
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,9 @@ var path = require('path');
 var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
-module.exports = {
-    devtool: 'cheap-module-eval-source-map',
+var env = process.env.NODE_ENV;
+
+var config = {
     entry: {
         'app': './src/apps/index.js'
     },
@@ -15,7 +16,9 @@ module.exports = {
     plugins: [
         new ExtractTextPlugin('main.css'),
         new webpack.optimize.OccurenceOrderPlugin(),
-        new webpack.NoErrorsPlugin()
+        new webpack.DefinePlugin({
+            'process.env.NODE_ENV': JSON.stringify(env)
+        })
     ],
     module: {
         loaders: [
@@ -49,3 +52,23 @@ module.exports = {
         ]
     }
 };
+
+if (env === 'production') {
+    config.plugins.push(
+        new webpack.optimize.UglifyJsPlugin({
+            compressor: {
+                pure_getters: true,
+                unsafe: true,
+                unsafe_comps: true,
+                screw_ie8: true,
+                warnings: false
+            }
+        })
+    );
+}
+else {
+    config['devtool'] = 'cheap-module-eval-source-map';
+    config.plugins.push(new webpack.NoErrorsPlugin());
+}
+
+module.exports = config;


### PR DESCRIPTION
Remove devtool and errors plugin for production build and uglify
javascript code. Doing this trims the js blob from 11.6MB to 1.6MB.
Horray!

@go-oleg 

cc @demmer