### PR TITLE
production build: don't do unsafe things when uglifying

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,8 +59,8 @@ if (env === 'production') {
         new webpack.optimize.UglifyJsPlugin({
             compressor: {
                 pure_getters: true,
-                unsafe: true,
-                unsafe_comps: true,
+                unsafe: false,
+                unsafe_comps: false,
                 screw_ie8: true,
                 warnings: false
             }


### PR DESCRIPTION
The duration input control wasn't working correctly in the production build but was working fine in the dev build. Tried changing the unsafe flags to `false` and it works now. Didn't spend much time tracking down what about uglifying unsafely was causing the problem...seems like 'being safe' is a reasonable thing to do.

@mnibecker 