### PR TITLE
Support bundle id

### DIFF
--- a/src/apps/actions.js
+++ b/src/apps/actions.js
@@ -2,9 +2,10 @@ export const NEW_BUNDLE = 'NEW_BUNDLE';
 export const NEW_ERROR = 'NEW_ERROR';
 export const FETCH_BUNDLE_ERROR = 'FETCH_BUNDLE_ERROR';
 
-export function newBundle(bundle, inputs) {
+export function newBundle(bundleId, bundle, inputs) {
     return {
         type: NEW_BUNDLE,
+        bundleId,
         bundle,
         inputs
     };
@@ -17,9 +18,10 @@ export function newError(error) {
     };
 }
 
-export function fetchBundleError(error) {
+export function fetchBundleError(bundleId, error) {
     return {
         type: FETCH_BUNDLE_ERROR,
+        bundleId,
         error
     };
 }

--- a/src/apps/components/error-view.js
+++ b/src/apps/components/error-view.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Juttle from 'juttle-client-library';
+
+export default class ErrorView extends React.Component {
+    componentDidMount() {
+        let client = new Juttle(this.props.juttleServiceHost);
+        this.error = new client.Errors(this.refs.errorDiv);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        if (!nextProps.error) {
+            this.error.clear();
+        } else {
+            this.error.render(nextProps.error);
+        }
+    }
+
+    render() {
+        return (
+            <div ref="errorDiv"></div>
+        );
+    }
+}
+

--- a/src/apps/components/run.js
+++ b/src/apps/components/run.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import _ from 'underscore';
 
 import * as actions from '../actions';
 
 import Juttle from 'juttle-client-library';
 import JuttleViewer from './juttle-viewer';
+import ErrorView from './error-view';
 
 const ENTER_KEY = 13;
 
@@ -15,7 +15,6 @@ class RunApp extends React.Component {
         let client = new Juttle(this.props.juttleServiceHost);
         this.view = new client.View(this.refs.juttleViewLayout);
         this.inputs = new client.Input(this.refs.juttleInputsContainer);
-        this.errors = new client.Errors(this.refs.errorView);
 
         // subscribe to runtime errors
         this.view.on('error', this.runtimeError.bind(this, 'error'));
@@ -31,7 +30,6 @@ class RunApp extends React.Component {
     componentWillReceiveProps(nextProps) {
         let self = this;
         if (nextProps.bundle !== this.props.bundle) {
-            this.errors.clear();
             this.inputs.clear();
 
             this.view.clear()
@@ -44,10 +42,6 @@ class RunApp extends React.Component {
                     }
                 }
             })
-        }
-
-        if (nextProps.error && !_.isEqual(nextProps.error, this.props.error)) {
-            this.errors.render(nextProps.error);
         }
     }
 
@@ -76,7 +70,7 @@ class RunApp extends React.Component {
                     <JuttleViewer bundle={this.props.bundle} />
                     <div ref="juttleSource"></div>
                     <div ref="juttleViewLayout"></div>
-                    <div ref="errorView"></div>
+                    <ErrorView error={this.props.error} />
                 </div>
                 <div className="right-rail">
                     <div ref="juttleInputsContainer" onKeyDown={this._onInputContainerKeyDown}></div>

--- a/src/apps/observers.js
+++ b/src/apps/observers.js
@@ -10,12 +10,12 @@ function runMode(store) {
 
 
     function runModeChanged(runMode) {
-        function bundleReceived(bundle) {
+        function bundleReceived(bundleId, bundle) {
             return api.describe(juttleServiceHost, bundle)
             .then(inputs => {
-                store.dispatch(newBundle(bundle, inputs));
+                store.dispatch(newBundle(bundleId, bundle, inputs));
             })
-            .catch(err => { store.dispatch(fetchBundleError(err)) })
+            .catch(err => { store.dispatch(fetchBundleError(bundleId, err)) })
         }
 
         if (rendezvous) {
@@ -24,11 +24,11 @@ function runMode(store) {
 
         if (runMode.path) {
             api.getBundle(juttleServiceHost, runMode.path)
-            .then(res => bundleReceived(res.bundle))
-            .catch(err => { store.dispatch(fetchBundleError(err)) })
+            .then(res => bundleReceived(runMode.path, res.bundle))
+            .catch(err => { store.dispatch(fetchBundleError(runMode.path, err)) })
         } else if (runMode.rendezvous) {
             rendezvous = new RendezvousSocket(`ws://${juttleServiceHost}/rendezvous/${runMode.rendezvous}`);
-            rendezvous.on('message', msg => bundleReceived(msg.bundle));
+            rendezvous.on('message', msg => bundleReceived(msg.bundle_id, msg.bundle));
         }
     }
 

--- a/src/apps/reducers.js
+++ b/src/apps/reducers.js
@@ -23,6 +23,7 @@ function runMode(state = { path: null, rendezvous: null }, action) {
 }
 
 const defaultBundleInfo = {
+    bundleId: null,
     bundle: null,
     inputs: null,
     error: null
@@ -32,6 +33,7 @@ function bundleInfo(state = defaultBundleInfo, action) {
     switch (action.type) {
         case NEW_BUNDLE:
             return {
+                bundleId: action.bundleId,
                 bundle: action.bundle,
                 inputs: action.inputs,
                 error: null
@@ -42,6 +44,7 @@ function bundleInfo(state = defaultBundleInfo, action) {
             });
         case FETCH_BUNDLE_ERROR:
             return {
+                bundleId: action.bundleId,
                 bundle: null,
                 inputs: null,
                 error: action.error

--- a/test/observers.spec.js
+++ b/test/observers.spec.js
@@ -1,4 +1,5 @@
 'use strict';
+import Promise from 'bluebird';
 import observers from '../src/apps/observers';
 import findFreePort from 'find-free-port';
 import nock from 'nock';
@@ -57,7 +58,7 @@ describe('bundleMiddleware', () => {
         nock.cleanAll();
     })
 
-    it('properly fetches bundle from null runMode', (done) => {
+    it('properly fetches bundle from null runMode', () => {
         const fakeJuttle1 = {
             program: 'emit -limit 101',
             modules: []
@@ -77,26 +78,31 @@ describe('bundleMiddleware', () => {
             runMode: { path: null, rendezvous: null }
         });
 
-        store.event.once(NEW_BUNDLE, (action) => {
+        return new Promise((resolve, reject) => {
+            store.event.once(NEW_BUNDLE, (action) => {
+                resolve(action);
+            });
+
+            store.updateState({
+                runMode: {
+                    path: '/fake1.juttle',
+                    rendezvous: null
+                }
+            });
+        })
+        .then(action => {
             expect(action).to.deep.equal({
                 type: NEW_BUNDLE,
+                bundleId: '/fake1.juttle',
                 bundle: fakeJuttle1,
                 inputs: []
             });
+        })
 
-            done();
-        });
-
-        store.updateState({
-            runMode: {
-                path: '/fake1.juttle',
-                rendezvous: null
-            }
-        });
 
     });
 
-    it('fetches bundle from path set runMode', (done) => {
+    it('fetches bundle from path set runMode', () => {
         const fakeJuttle2 = {
             program: 'emit -limit 102',
             modules: []
@@ -120,26 +126,29 @@ describe('bundleMiddleware', () => {
             }
         });
 
+        return new Promise(resolve => {
+            store.event.once(NEW_BUNDLE, (action) => {
+                resolve(action);
+            });
 
-        store.event.once(NEW_BUNDLE, (action) => {
+            store.updateState({
+                runMode: {
+                    path: '/fake2.juttle',
+                    rendezvous: null
+                }
+            });
+        })
+        .then(action => {
             expect(action).to.deep.equal({
                 type: NEW_BUNDLE,
+                bundleId: '/fake2.juttle',
                 bundle: fakeJuttle2,
                 inputs: []
             });
-
-            done();
-        });
-
-        store.updateState({
-            runMode: {
-                path: '/fake2.juttle',
-                rendezvous: null
-            }
         });
     });
 
-    it('receives bundle for rendezvous runMode', (done) => {
+    it('receives bundle for rendezvous runMode', () => {
         const rendezJuttle = {
             program: 'emit -limit 9000',
             modules: []
@@ -163,26 +172,31 @@ describe('bundleMiddleware', () => {
             }
         });
 
-        store.event.once(NEW_BUNDLE, (action) => {
+        return new Promise(resolve => {
+            store.event.once(NEW_BUNDLE, (action) => {
+                resolve(action);
+            });
+
+            store.updateState({
+                runMode: {
+                    path: null,
+                    rendezvous: 'test'
+                }
+            });
+
+            mockServer.send(JSON.stringify({
+                bundle_id: 'test.juttle',
+                bundle: rendezJuttle
+            }));
+        })
+        .then(action => {
             expect(action).to.deep.equal({
                 type: NEW_BUNDLE,
+                bundleId: 'test.juttle',
                 bundle: rendezJuttle,
                 inputs: []
             });
-
-            done();
         });
-
-        store.updateState({
-            runMode: {
-                path: null,
-                rendezvous: 'test'
-            }
-        });
-
-        mockServer.send(JSON.stringify({
-            bundle: rendezJuttle
-        }));
     });
 
 });

--- a/test/reducers.spec.js
+++ b/test/reducers.spec.js
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+
+import reducers from '../src/apps/reducers';
+import * as actions from '../src/apps/actions';
+
+describe('reducers', () => {
+    describe('bundleInfo reducer', () => {
+        const fakeBundle1 = { program: 'emit -limit 1', modules: [] };
+        const fakeBundle2 = { program: 'emit -limit 1000', modules: [] };
+
+        it('should return initial state', () => {
+            expect(
+                reducers(undefined, {}).bundleInfo
+            ).to.deep.equal({
+                bundleId: null,
+                bundle: null,
+                inputs: null,
+                error: null
+            });
+        });
+
+        it('reset error with NEW_BUNDLE event', () => {
+            const startBundleInfo = {
+                bundleId: 'test',
+                bundle: fakeBundle1,
+                inputs: {},
+                error: 'i am angry'
+            }
+
+            const endBundleInfo = {
+                bundleId: 'test2',
+                bundle: fakeBundle2,
+                inputs: {},
+                error: null
+            }
+
+            expect(
+                reducers(
+                    { bundleInfo: startBundleInfo},
+                    actions.newBundle(endBundleInfo.bundleId, endBundleInfo.bundle, endBundleInfo.inputs)
+                ).bundleInfo
+            ).to.deep.equal(endBundleInfo);
+        });
+
+        it('fetch bundle error stores bundleId', () => {
+            const startBundleInfo = {
+                bundleId: 'test',
+                bundle: fakeBundle1,
+                inputs: {},
+                error: null
+            };
+
+            const endBundleInfo = {
+                bundleId: 'test',
+                bundle: null,
+                inputs: null,
+                error: {
+                    code: 'TEST-ERROR',
+                    message: 'there was an error',
+                    info: {}
+                }
+            };
+
+            expect(
+                reducers(
+                    { bundleInfo: startBundleInfo },
+                    actions.fetchBundleError('test', endBundleInfo.error)
+                ).bundleInfo
+            ).to.deep.equal(endBundleInfo);
+        });
+    });
+});


### PR DESCRIPTION
Simplified version of #31 

- Use bundleId to determine if we have received a new bundle. If new bundle, inputs should be reset. 
- Add tests for reducers
- Simplify `run.js` by moving error rendering to its own component.

@go-oleg 