### PR TITLE
styling: fix date input's calendar styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "isparta": "^4.0.0",
     "jsdom": "^8.1.0",
     "json-loader": "^0.5.4",
-    "juttle-client-library": "^0.7.0-rc.5",
+    "juttle-client-library": "^0.7.0-rc.6",
     "mock-socket": "^2.0.0",
     "nock": "^7.0.2",
     "node-sass": "^3.4.2",

--- a/src/apps/assets/sass/_juttle-client-library-overrides.scss
+++ b/src/apps/assets/sass/_juttle-client-library-overrides.scss
@@ -24,6 +24,34 @@
             background-color: $component-active-bg;
         }
     }
+
+    .datepicker,
+    .datepicker__input,
+    .datepicker__input:focus,
+    .datepicker__month .datepicker__day {
+        background-color: $input-bg;
+        color: $input-color;
+        border-color: $input-border;
+        box-shadow: none;
+    }
+
+    .datepicker__month .datepicker__day--selected {
+        background-color: $component-active-bg;
+    }
+
+    .datepicker__month .datepicker__day:hover {
+        background-color: $input-border;
+    }
+
+    .datepicker__current-month,
+    .datepicker__day {
+        color: $input-color;
+    }
+
+    .datepicker__header {
+        background-color: $input-border;
+        color: $input-color;
+    }
 }
 
 .juttle-client-library.inputs-view {
@@ -33,32 +61,4 @@
         min-width: 250px;
         margin-right: 20px;
     }
-}
-
-.datepicker,
-.datepicker__input,
-.datepicker__input:focus,
-.datepicker__month .datepicker__day {
-    background-color: $input-bg;
-    color: $input-color;
-    border-color: $input-border;
-    box-shadow: none;
-}
-
-.datepicker__month .datepicker__day--selected {
-    background-color: $component-active-bg;
-}
-
-.datepicker__month .datepicker__day:hover {
-    background-color: $input-border;
-}
-
-.datepicker__current-month,
-.datepicker__day {
-    color: $input-color;
-}
-
-.datepicker__header {
-    background-color: $input-border;
-    color: $input-color;
 }


### PR DESCRIPTION
In https://github.com/juttle/juttle-client-library/pull/74, the location where the date input's calendar popup is attached changed. Fix styling to accomadate for this (move datepicker style overrides to be nested under `.juttle-client-library`).

@mnibecker 