### PR TITLE
Fix moar app height issues

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,8 @@ require('babel-core/register');
 
 gulp.task('instrument', function () {
     return gulp.src([
-        'src/**/*.js'
+        'src/**/*.js',
+        '!src/apps/index.js'
     ])
     .pipe(istanbul({
         includeUntested: true,

--- a/src/apps/assets/sass/main.scss
+++ b/src/apps/assets/sass/main.scss
@@ -7,10 +7,17 @@
 @import "./components/directory-listing";
 @import "./components/font-button";
 
+body, #app {
+    @include flexbox;
+    min-height: 100vh;
+    flex-direction: column
+}
+
 .app-main {
     width: 100%;
     height:100%;
     overflow-x: hidden;
+    @include flex-grow(1);
     @include flexbox;
     @include flex-direction(column);
 }


### PR DESCRIPTION
The previous change #48 was causing the dropdown to get cut off when the
page was empty.

This was the issue:
![screen shot 2016-03-10 at 9 52 47 am](https://cloud.githubusercontent.com/assets/2147549/13678871/e1e0561e-e6a5-11e5-9a80-9d0dbafacc16.png)

@go-oleg @davidvgalbraith @VladVega 
