### PR TITLE
adds the babel transform-object-assign plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
-    "plugins": ["transform-class-properties"],
+    "plugins": [
+        "transform-class-properties",
+        "transform-object-assign"
+    ],
     "presets": ["react", "es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-eslint": "^4.1.8",
     "babel-loader": "^6.2.1",
     "babel-plugin-transform-class-properties": "^6.4.0",
+    "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "bluebird": "^3.2.1",


### PR DESCRIPTION
fixes https://github.com/juttle/juttle-engine/issues/93

this basically fixes the problem of older browsers, specifically chrome
v42 not having the Object.assign method