### PR TITLE
Move client deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
   },
   "homepage": "https://github.com/juttle/juttle-viewer#readme",
   "dependencies": {
-    "brace": "^0.7.0",
     "express": "^4.13.4",
-    "juttle-react-ace": "^3.1.0",
-    "redux-thunk": "^2.0.1",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
@@ -52,6 +49,7 @@
     "bluebird": "^3.2.1",
     "bluebird-retry": "^0.5.3",
     "bootstrap-sass": "^3.3.6",
+    "brace": "^0.7.0",
     "chai": "^3.5.0",
     "classnames": "^2.2.3",
     "css-loader": "^0.23.1",
@@ -72,6 +70,7 @@
     "jsdom": "^8.1.0",
     "json-loader": "^0.5.4",
     "juttle-client-library": "^0.7.0",
+    "juttle-react-ace": "^3.1.0",
     "mock-socket": "^2.0.0",
     "nock": "^7.0.2",
     "node-sass": "^3.4.2",
@@ -82,6 +81,7 @@
     "react-router": "^2.0.0-rc6",
     "react-router-redux": "^3.0.0",
     "redux": "^3.3.0",
+    "redux-thunk": "^2.0.1",
     "resolve-url-loader": "^1.4.3",
     "rimraf": "^2.5.1",
     "sass-loader": "^3.1.2",


### PR DESCRIPTION
On prepublish we morph all client side code to a giant js blob. As such
move new client side dependencies to devDependencies.

@go-oleg @davidvgalbraith @VladVega