### PR TITLE
change juttle browser icon label from 'path' to 'browse'

### DIFF
--- a/src/client-lib/dropdown/index.js
+++ b/src/client-lib/dropdown/index.js
@@ -54,7 +54,7 @@ class Dropdown extends React.Component {
                         onTouchEnd={this._handleMouseDown}
                         type="button">
                         <i className="fa fa-lg fa-folder fa-fw"></i>
-                        <div className="font-btn-name">path</div>
+                        <div className="font-btn-name">open</div>
                     </button>
                 </div>
                 <div id="directory-listing" className="dropdown-menu">


### PR DESCRIPTION
I think "browse" is a better term than "path" because its a verb/call-to-action.

@mnibecker @demmer @dmehra thoughts?

![image](https://cloud.githubusercontent.com/assets/3344137/13862401/4c549294-ec50-11e5-87e0-7c08aa78dc6d.png)